### PR TITLE
actual fix for word breaking

### DIFF
--- a/src/components/AnimatedMarkdown.tsx
+++ b/src/components/AnimatedMarkdown.tsx
@@ -180,8 +180,17 @@ const MarkdownAnimateText: React.FC<SmoothTextProps> = ({
         let lastIndex = 0;
 
         if (fullPatterns.length === 0) {
-            return [text];
-        }
+            return [
+              <TokenizedText
+                input={text}
+                sep={sep}
+                animation={animation}
+                animationDuration={animationDuration}
+                animationTimingFunction={animationTimingFunction}
+                animationIterationCount={1}
+              />,
+            ];
+          }
 
         // Use matchAll to find each match and its position
         for (const match of remainingText.matchAll(regex)) {


### PR DESCRIPTION
Added proper fix for word breaking. Previous fix did not wrap in TokenizedText, therefore the text was never tokenized in words or chars.

#12 